### PR TITLE
Add in LogBox and onException errors if available for all proxies

### DIFF
--- a/models/BaseProxy.cfc
+++ b/models/BaseProxy.cfc
@@ -213,4 +213,43 @@ component accessors="true" {
 		return ( findNoCase( "ForkJoinPool", getThreadName() ) NEQ 0 );
 	}
 
+	void function sendExceptionToLogBoxIfAvailable( required any exception ){
+		if ( !variables.loadAppContext ) {
+			return;
+		}
+
+		if ( !structKeyExists( application, "cbController" ) ) {
+			return;
+		}
+
+		try {
+			application.cbController
+				.getLogBox()
+				.getRootLogger()
+				.error( arguments.exception.message, arguments.exception );
+		} catch ( any e ) {
+			err( "Error trying to send exception to LogBox: #e.message & e.detail#" );
+			err( "Stacktrace trying to send exception to LogBox: #e.stackTrace#" );
+		}
+	}
+
+	void function sendExceptionToOnExceptionIfAvailable( required any exception ){
+		if ( !variables.loadAppContext ) {
+			return;
+		}
+
+		if ( !structKeyExists( application, "cbController" ) ) {
+			return;
+		}
+
+		try {
+			application.cbController
+				.getInterceptorService()
+				.announce( "onException", { exception : arguments.exception } );
+		} catch ( any e ) {
+			err( "Error trying to announce exception to the ColdBox onException interception point: #e.message & e.detail#" );
+			err( "Stacktrace announcing exception to the ColdBox onException interception point: #e.stackTrace#" );
+		}
+	}
+
 }

--- a/models/BaseProxy.cfc
+++ b/models/BaseProxy.cfc
@@ -218,12 +218,12 @@ component accessors="true" {
 			return;
 		}
 
-		if ( !structKeyExists( application, "cbController" ) ) {
+		if ( !structKeyExists( application, "wirebox" ) ) {
 			return;
 		}
 
 		try {
-			application.cbController
+			application.wirebox
 				.getLogBox()
 				.getRootLogger()
 				.error( arguments.exception.message, arguments.exception );
@@ -238,13 +238,13 @@ component accessors="true" {
 			return;
 		}
 
-		if ( !structKeyExists( application, "cbController" ) ) {
+		if ( !structKeyExists( application, "wirebox" ) ) {
 			return;
 		}
 
 		try {
-			application.cbController
-				.getInterceptorService()
+			application.wirebox
+				.getEventManager()
 				.announce( "onException", { exception : arguments.exception } );
 		} catch ( any e ) {
 			err( "Error trying to announce exception to the ColdBox onException interception point: #e.message & e.detail#" );

--- a/models/BiConsumer.cfc
+++ b/models/BiConsumer.cfc
@@ -28,6 +28,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running BiConsumer: #e.message & e.detail#" );
 			err( "Stacktrace for BiConsumer: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/BiFunction.cfc
+++ b/models/BiFunction.cfc
@@ -31,6 +31,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running BiFunction: #e.message & e.detail#" );
 			err( "Stacktrace for BiFunction: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Callable.cfc
+++ b/models/Callable.cfc
@@ -18,6 +18,8 @@ component extends="Supplier" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Callable: #e.message & e.detail#" );
 			err( "Stacktrace for Callable: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Comparator.cfc
+++ b/models/Comparator.cfc
@@ -28,6 +28,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Comparator: #e.message & e.detail#" );
 			err( "Stacktrace for Comparator: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Consumer.cfc
+++ b/models/Consumer.cfc
@@ -28,6 +28,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Consumer: #e.message & e.detail#" );
 			err( "Stacktrace for Consumer: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Function.cfc
+++ b/models/Function.cfc
@@ -40,6 +40,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Function: #e.message & e.detail#" );
 			err( "Stacktrace for Function: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/FutureFunction.cfc
+++ b/models/FutureFunction.cfc
@@ -31,6 +31,8 @@ component extends="Function" {
 			// Log it, so it doesn't go to ether
 			err( "Error running FutureFunction: #e.message & e.detail#" );
 			err( "Stacktrace for FutureFunction: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Predicate.cfc
+++ b/models/Predicate.cfc
@@ -36,6 +36,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Predicate: #e.message & e.detail#" );
 			err( "Stacktrace for Predicate: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Runnable.cfc
+++ b/models/Runnable.cfc
@@ -41,6 +41,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running runnable: #e.message & e.detail#" );
 			err( "Stacktrace for runnable: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/Supplier.cfc
+++ b/models/Supplier.cfc
@@ -41,6 +41,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running Supplier: #e.message & e.detail#" );
 			err( "Stacktrace for Supplier: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/ToDoubleFunction.cfc
+++ b/models/ToDoubleFunction.cfc
@@ -27,6 +27,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running ToDoubleFunction: #e.message & e.detail#" );
 			err( "Stacktrace for ToDoubleFunction: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/ToIntFunction.cfc
+++ b/models/ToIntFunction.cfc
@@ -27,6 +27,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running ToIntFunction: #e.message & e.detail#" );
 			err( "Stacktrace for ToIntFunction: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();

--- a/models/ToLongFunction.cfc
+++ b/models/ToLongFunction.cfc
@@ -27,6 +27,8 @@ component extends="BaseProxy" {
 			// Log it, so it doesn't go to ether
 			err( "Error running toLongFunction: #e.message & e.detail#" );
 			err( "Stacktrace for toLongFunction: #e.stackTrace#" );
+			sendExceptionToLogBoxIfAvailable( e );
+			sendExceptionToOnExceptionIfAvailable( e );
 			rethrow;
 		} finally {
 			unLoadContext();


### PR DESCRIPTION
This PR tries to send exceptions to both the LogBox root logger and the onException interception point if those are available.  It determines if those are available by first checking if the app context was loaded and then by checking the application scope for `cbController`.

- [x] Improvement

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
